### PR TITLE
Fixed behaviour of spawn position indicator

### DIFF
--- a/Assets/Scripts/ARTapActions.cs
+++ b/Assets/Scripts/ARTapActions.cs
@@ -35,18 +35,17 @@ public class ARTapActions : MonoBehaviour
     {
         if (_gameManager.CurrentGameState != GameManager.GameState.None)
         {
-            _spawnPosition.SetActive(true);
-
+            UpdatePlacementPosition();
+            UpdatePlacementIndicator();
             if (_touchIsPressed)
             {
-                UpdatePlacementPosition();
-                UpdatePlacementIndicator();
+                _spawnPosition.SetActive(true);
             }
 
             if (_touchIsReleased)
             {
-                UpdatePlacementPosition();
-                UpdatePlacementIndicator();
+                _spawnPosition.SetActive(false);
+
                 InstantiateOrHealUpWarrior();
                 _touchIsPressed = false;
                 _touchIsReleased = false;


### PR DESCRIPTION
Now spawn position indicator appears on tap or drag and then after selecting precise location where to put the unit it disappears after the unit is spawned